### PR TITLE
Typo in chapter 43 heading

### DIFF
--- a/src/epub/text/chapter-43.xhtml
+++ b/src/epub/text/chapter-43.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-GB">
 	<head>
-		<title>XLIII: Mike Recieves a Commission</title>
+		<title>XLIII: Mike Receives a Commission</title>
 		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
 		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
 	</head>
@@ -9,7 +9,7 @@
 		<section id="chapter-43" epub:type="chapter">
 			<hgroup>
 				<h2 epub:type="ordinal z3998:roman">XLIII</h2>
-				<p epub:type="title">Mike Recieves a Commission</p>
+				<p epub:type="title">Mike Receives a Commission</p>
 			</hgroup>
 			<p>There is only one thing to be said in favour of detention on a fine summer’s afternoon, and that is that it is very pleasant to come out of. The sun never seems so bright or the turf so green as during the first five minutes after one has come out of the detention-room. One feels as if one were entering a new and very delightful world. There is also a touch of the Rip van Winkle feeling. Everything seems to have gone on and left one behind. Mike, as he walked to the cricket field, felt very much behind the times.</p>
 			<p>Arriving on the field he found the Old Boys batting. He stopped and watched an over of Adair’s. The fifth ball bowled a man. Mike made his way towards the pavilion.</p>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -146,7 +146,7 @@
 							<a href="text/chapter-42.xhtml"><span epub:type="z3998:roman">XLII</span>: Jellicoe Goes on the Sick-List</a>
 						</li>
 						<li>
-							<a href="text/chapter-43.xhtml"><span epub:type="z3998:roman">XLIII</span>: Mike Recieves a Commission</a>
+							<a href="text/chapter-43.xhtml"><span epub:type="z3998:roman">XLIII</span>: Mike Receives a Commission</a>
 						</li>
 						<li>
 							<a href="text/chapter-44.xhtml"><span epub:type="z3998:roman">XLIV</span>: And Fulfils It</a>


### PR DESCRIPTION
Incorrect spelling of "receive". Checked against https://www.gutenberg.org/cache/epub/10586/pg10586.txt and confirm only standard ebooks has this error.